### PR TITLE
stat.js: definiálatlan operator tag kezelése

### DIFF
--- a/js/stat.js
+++ b/js/stat.js
@@ -29,7 +29,7 @@ function hasCellId (feature) {
 function getVisibleItems (feature, key) {
 	if (!feature.n.tags[key]) return;
 	var out = [];
-	operators = feature.n.tags.operator.split('; ');
+	operators = (feature.n.tags.operator || '').split('; ');
 	items = feature.n.tags[key].split('; ');
 	for (var i=0; i<operators.length; i++) {
 		operator = operators[i];


### PR DESCRIPTION
Ha bekapcsolom az ismeretlen szolgáltatók megjelenítését, ezt a hibát kapom:
Uncaught TypeError: Cannot read property 'split' of undefined at getVisibleItems (stat.js:32)

(ez az OSM pont okozta: https://www.openstreetmap.org/node/3760004759/history)