### PR TITLE
Use eNB instead of cellid on LTE

### DIFF
--- a/js/stat.js
+++ b/js/stat.js
@@ -23,7 +23,7 @@ function hasCellId (feature) {
 	return !(
 		!feature.getProperties().tags['gsm:cellid'] &&
 		!feature.getProperties().tags['umts:cellid'] &&
-		!feature.getProperties().tags['lte:cellid']
+		!feature.getProperties().tags['lte:eNB']
 	);
 }
 


### PR DESCRIPTION
On 4G/LTE connection, the eNB (short for eNodeB) identifies the tower uniquely instead of the cellid which identifies only sectors.